### PR TITLE
chore: fix minor typo in FirstReduceChallenge

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -19,7 +19,7 @@ pub struct FirstReduceMessage<G1, G2, GT> {
     pub e2_beta: G2,
 }
 
-/// The the first verifier challenge in the Dory-Reduce portion (Section 3.2) of the Dory protocol.
+/// The first verifier challenge in the Dory-Reduce portion (Section 3.2) of the Dory protocol.
 ///
 /// The challenge, $\beta$, is a random scalar. Additionally, $\beta$ must be non-zero because
 /// the protocol uses $\beta^{-1}$, which we also include here.


### PR DESCRIPTION
### Rationale for this change  
Just cleaning up a minor typo to improve readability and maintain polish across the codebase.

### What changes are included in this PR?  
<img width="776" alt="Снимок экрана 2025-04-18 в 13 44 47" src="https://github.com/user-attachments/assets/bd5233d9-fb21-4089-baac-c601828fb6ad" />
Removed the duplicate "The" in the FirstReduceChallenge docstring.

### Are these changes tested?  
No tests needed—docstring only, no functional changes.