### PR TITLE
test: add tests covering inner product proof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ exclude = [".github", "README.md"]
 [dependencies]
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 
+[dev-dependencies]
+rand = { version = "0.9.2" }
+
 [lints.rust]
 missing_docs = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [".github", "README.md"]
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
+mockall = { version = "0.13.1" }
 rand = { version = "0.9.2" }
 
 [lints.rust]

--- a/src/inner_product.rs
+++ b/src/inner_product.rs
@@ -25,3 +25,183 @@ where
     let (challenge, builder) = builder.challenge_fold_scalars();
     builder.append_scalar_product_message(state.compute_scalar_product_message(setup, challenge))
 }
+
+/// These tests are quite convoluted, and are mostly here to ensure 100% code coverage.
+#[cfg(test)]
+mod tests {
+    use mockall::{mock, Sequence};
+    use rand::Rng;
+
+    use crate::messages::{
+        FirstReduceChallenge, FirstReduceMessage, FoldScalarsChallenge, ScalarProductMessage,
+        SecondReduceChallenge, SecondReduceMessage,
+    };
+    use crate::{inner_product_prove, ProofBuilder, ProverState};
+
+    mock! {
+        pub ProofBuilder {}
+        impl ProofBuilder for ProofBuilder {
+            type G1 = u32;
+            type G2 = u32;
+            type GT = u32;
+            type Scalar = u32;
+            fn append_first_reduce_message(
+                self,
+                message: FirstReduceMessage<u32, u32, u32>,
+            ) -> (FirstReduceChallenge<u32>, Self);
+            fn append_second_reduce_message(
+                self,
+                message: SecondReduceMessage<u32, u32, u32>,
+            ) -> (SecondReduceChallenge<u32>, Self);
+            fn challenge_fold_scalars(self) -> (FoldScalarsChallenge<u32>, Self);
+            fn append_scalar_product_message(self, message: ScalarProductMessage<u32, u32>)
+                -> Self;
+        }
+    }
+
+    mock! {
+        pub ProverState {}
+        impl ProverState for ProverState {
+            type G1 = u32;
+            type G2 = u32;
+            type GT = u32;
+            type Scalar = u32;
+            type Setup = u32;
+            fn compute_first_reduce_message(
+                &self,
+                setup: &u32,
+            ) -> FirstReduceMessage<u32, u32, u32>;
+            fn reduce_combine(
+                self,
+                setup: &u32,
+                first_challenge: FirstReduceChallenge<u32>,
+            ) -> Self;
+            fn compute_second_reduce_message(
+                &self,
+                setup: &u32,
+            ) -> SecondReduceMessage<u32, u32, u32>;
+            fn reduce_fold(self, setup: &u32, second_challenge: SecondReduceChallenge<u32>)
+                -> Self;
+            fn compute_scalar_product_message(
+                self,
+                setup: &u32,
+                fold_challenge: FoldScalarsChallenge<u32>,
+            ) -> ScalarProductMessage<u32, u32>;
+        }
+    }
+
+    #[test]
+    fn we_can_prove_inner_product_with_1_round() {
+        let rng = &mut rand::rng();
+
+        let mock_setup: u32 = rng.random();
+
+        // Round 0 messages and challenges
+        let mock_first_reduce_message_0: FirstReduceMessage<u32, u32, u32> = rng.random();
+        let mock_first_reduce_challenge_0: FirstReduceChallenge<u32> = rng.random();
+        let mock_second_reduce_message_0: SecondReduceMessage<u32, u32, u32> = rng.random();
+        let mock_second_reduce_challenge_0: SecondReduceChallenge<u32> = rng.random();
+
+        // Final fold and scalar product
+        let mock_fold_scalars_challenge: FoldScalarsChallenge<u32> = rng.random();
+        let mock_scalar_product_message: ScalarProductMessage<u32, u32> = rng.random();
+
+        let mut builder = MockProofBuilder::new();
+
+        // Round 0 - First reduce message
+        builder
+            .expect_append_first_reduce_message()
+            .times(1)
+            .returning(move |message| {
+                assert_eq!(message, mock_first_reduce_message_0);
+                let mut builder = MockProofBuilder::new();
+
+                // Round 0 - Second reduce message
+                builder
+                    .expect_append_second_reduce_message()
+                    .times(1)
+                    .returning(move |message| {
+                        assert_eq!(message, mock_second_reduce_message_0);
+                        let mut builder = MockProofBuilder::new();
+
+                        // Final fold challenge
+                        builder
+                            .expect_challenge_fold_scalars()
+                            .times(1)
+                            .returning(move || {
+                                let mut builder = MockProofBuilder::new();
+
+                                // Final scalar product message
+                                builder
+                                    .expect_append_scalar_product_message()
+                                    .times(1)
+                                    .returning(move |message| {
+                                        assert_eq!(message, mock_scalar_product_message);
+                                        MockProofBuilder::new()
+                                    });
+                                (mock_fold_scalars_challenge, builder)
+                            });
+                        (mock_second_reduce_challenge_0, builder)
+                    });
+                (mock_first_reduce_challenge_0, builder)
+            });
+
+        let mut seq = Sequence::new();
+        let mut state = MockProverState::new();
+
+        // Round 0 - First reduce
+        state
+            .expect_compute_first_reduce_message()
+            .times(1)
+            .returning(move |setup| {
+                assert_eq!(setup, &mock_setup);
+                mock_first_reduce_message_0
+            })
+            .in_sequence(&mut seq);
+        state
+            .expect_reduce_combine()
+            .times(1)
+            .returning(move |setup, challenge| {
+                assert_eq!(setup, &mock_setup);
+                assert_eq!(challenge, mock_first_reduce_challenge_0);
+                let mut seq = Sequence::new();
+                let mut state = MockProverState::new();
+
+                // Round 0 - Second reduce
+                state
+                    .expect_compute_second_reduce_message()
+                    .times(1)
+                    .returning(move |setup| {
+                        assert_eq!(setup, &mock_setup);
+                        mock_second_reduce_message_0
+                    })
+                    .in_sequence(&mut seq);
+                state
+                    .expect_reduce_fold()
+                    .times(1)
+                    .returning(move |setup, challenge| {
+                        assert_eq!(setup, &mock_setup);
+                        assert_eq!(challenge, mock_second_reduce_challenge_0);
+                        let mut seq = Sequence::new();
+                        let mut state = MockProverState::new();
+
+                        // Final scalar product
+                        state
+                            .expect_compute_scalar_product_message()
+                            .times(1)
+                            .returning(move |setup, challenge| {
+                                assert_eq!(setup, &mock_setup);
+                                assert_eq!(challenge, mock_fold_scalars_challenge);
+                                mock_scalar_product_message
+                            })
+                            .in_sequence(&mut seq);
+                        state
+                    })
+                    .in_sequence(&mut seq);
+                state
+            })
+            .in_sequence(&mut seq);
+
+        inner_product_prove(builder, state, &mock_setup, 1);
+    }
+}

--- a/src/inner_product.rs
+++ b/src/inner_product.rs
@@ -204,4 +204,190 @@ mod tests {
 
         inner_product_prove(builder, state, &mock_setup, 1);
     }
+
+    #[test]
+    #[expect(clippy::too_many_lines)]
+    fn we_can_prove_inner_product_with_2_rounds() {
+        let rng = &mut rand::rng();
+
+        let mock_setup: u32 = rng.random();
+
+        // Round 0 messages and challenges
+        let mock_first_reduce_message_0: FirstReduceMessage<u32, u32, u32> = rng.random();
+        let mock_first_reduce_challenge_0: FirstReduceChallenge<u32> = rng.random();
+        let mock_second_reduce_message_0: SecondReduceMessage<u32, u32, u32> = rng.random();
+        let mock_second_reduce_challenge_0: SecondReduceChallenge<u32> = rng.random();
+
+        // Round 1 messages and challenges
+        let mock_first_reduce_message_1: FirstReduceMessage<u32, u32, u32> = rng.random();
+        let mock_first_reduce_challenge_1: FirstReduceChallenge<u32> = rng.random();
+        let mock_second_reduce_message_1: SecondReduceMessage<u32, u32, u32> = rng.random();
+        let mock_second_reduce_challenge_1: SecondReduceChallenge<u32> = rng.random();
+
+        // Final fold and scalar product
+        let mock_fold_scalars_challenge: FoldScalarsChallenge<u32> = rng.random();
+        let mock_scalar_product_message: ScalarProductMessage<u32, u32> = rng.random();
+
+        let mut builder = MockProofBuilder::new();
+
+        // Round 0 - First reduce message
+        builder
+            .expect_append_first_reduce_message()
+            .times(1)
+            .returning(move |message| {
+                assert_eq!(message, mock_first_reduce_message_0);
+                let mut builder = MockProofBuilder::new();
+
+                // Round 0 - Second reduce message
+                builder
+                    .expect_append_second_reduce_message()
+                    .times(1)
+                    .returning(move |message| {
+                        assert_eq!(message, mock_second_reduce_message_0);
+                        let mut builder = MockProofBuilder::new();
+
+                        // Round 1 - First reduce message
+                        builder
+                            .expect_append_first_reduce_message()
+                            .times(1)
+                            .returning(move |message| {
+                                assert_eq!(message, mock_first_reduce_message_1);
+                                let mut builder = MockProofBuilder::new();
+
+                                // Round 1 - Second reduce message
+                                builder
+                                    .expect_append_second_reduce_message()
+                                    .times(1)
+                                    .returning(move |message| {
+                                        assert_eq!(message, mock_second_reduce_message_1);
+                                        let mut builder = MockProofBuilder::new();
+
+                                        // Final fold challenge
+                                        builder.expect_challenge_fold_scalars().times(1).returning(
+                                            move || {
+                                                let mut builder = MockProofBuilder::new();
+
+                                                // Final scalar product message
+                                                builder
+                                                    .expect_append_scalar_product_message()
+                                                    .times(1)
+                                                    .returning(move |message| {
+                                                        assert_eq!(
+                                                            message,
+                                                            mock_scalar_product_message
+                                                        );
+                                                        MockProofBuilder::new()
+                                                    });
+                                                (mock_fold_scalars_challenge, builder)
+                                            },
+                                        );
+                                        (mock_second_reduce_challenge_1, builder)
+                                    });
+                                (mock_first_reduce_challenge_1, builder)
+                            });
+                        (mock_second_reduce_challenge_0, builder)
+                    });
+                (mock_first_reduce_challenge_0, builder)
+            });
+
+        let mut seq = Sequence::new();
+        let mut state = MockProverState::new();
+
+        // Round 0 - First reduce
+        state
+            .expect_compute_first_reduce_message()
+            .times(1)
+            .returning(move |setup| {
+                assert_eq!(setup, &mock_setup);
+                mock_first_reduce_message_0
+            })
+            .in_sequence(&mut seq);
+        state
+            .expect_reduce_combine()
+            .times(1)
+            .returning(move |setup, challenge| {
+                assert_eq!(setup, &mock_setup);
+                assert_eq!(challenge, mock_first_reduce_challenge_0);
+                let mut seq = Sequence::new();
+                let mut state = MockProverState::new();
+
+                // Round 0 - Second reduce
+                state
+                    .expect_compute_second_reduce_message()
+                    .times(1)
+                    .returning(move |setup| {
+                        assert_eq!(setup, &mock_setup);
+                        mock_second_reduce_message_0
+                    })
+                    .in_sequence(&mut seq);
+                state
+                    .expect_reduce_fold()
+                    .times(1)
+                    .returning(move |setup, challenge| {
+                        assert_eq!(setup, &mock_setup);
+                        assert_eq!(challenge, mock_second_reduce_challenge_0);
+                        let mut seq = Sequence::new();
+                        let mut state = MockProverState::new();
+
+                        // Round 1 - First reduce
+                        state
+                            .expect_compute_first_reduce_message()
+                            .times(1)
+                            .returning(move |setup| {
+                                assert_eq!(setup, &mock_setup);
+                                mock_first_reduce_message_1
+                            })
+                            .in_sequence(&mut seq);
+                        state
+                            .expect_reduce_combine()
+                            .times(1)
+                            .returning(move |setup, challenge| {
+                                assert_eq!(setup, &mock_setup);
+                                assert_eq!(challenge, mock_first_reduce_challenge_1);
+                                let mut seq = Sequence::new();
+                                let mut state = MockProverState::new();
+
+                                // Round 1 - Second reduce
+                                state
+                                    .expect_compute_second_reduce_message()
+                                    .times(1)
+                                    .returning(move |setup| {
+                                        assert_eq!(setup, &mock_setup);
+                                        mock_second_reduce_message_1
+                                    })
+                                    .in_sequence(&mut seq);
+                                state
+                                    .expect_reduce_fold()
+                                    .times(1)
+                                    .returning(move |setup, challenge| {
+                                        assert_eq!(setup, &mock_setup);
+                                        assert_eq!(challenge, mock_second_reduce_challenge_1);
+                                        let mut seq = Sequence::new();
+                                        let mut state = MockProverState::new();
+
+                                        // Final scalar product
+                                        state
+                                            .expect_compute_scalar_product_message()
+                                            .times(1)
+                                            .returning(move |setup, challenge| {
+                                                assert_eq!(setup, &mock_setup);
+                                                assert_eq!(challenge, mock_fold_scalars_challenge);
+                                                mock_scalar_product_message
+                                            })
+                                            .in_sequence(&mut seq);
+                                        state
+                                    })
+                                    .in_sequence(&mut seq);
+                                state
+                            })
+                            .in_sequence(&mut seq);
+                        state
+                    })
+                    .in_sequence(&mut seq);
+                state
+            })
+            .in_sequence(&mut seq);
+
+        inner_product_prove(builder, state, &mock_setup, 2);
+    }
 }

--- a/src/inner_product.rs
+++ b/src/inner_product.rs
@@ -91,6 +91,53 @@ mod tests {
     }
 
     #[test]
+    fn we_can_prove_inner_product_with_0_rounds() {
+        let rng = &mut rand::rng();
+
+        let mock_setup: u32 = rng.random();
+
+        // Final fold and scalar product (no reduce rounds)
+        let mock_fold_scalars_challenge: FoldScalarsChallenge<u32> = rng.random();
+        let mock_scalar_product_message: ScalarProductMessage<u32, u32> = rng.random();
+
+        let mut builder = MockProofBuilder::new();
+
+        // Final fold challenge (no reduce messages)
+        builder
+            .expect_challenge_fold_scalars()
+            .times(1)
+            .returning(move || {
+                let mut builder = MockProofBuilder::new();
+
+                // Final scalar product message
+                builder
+                    .expect_append_scalar_product_message()
+                    .times(1)
+                    .returning(move |message| {
+                        assert_eq!(message, mock_scalar_product_message);
+                        MockProofBuilder::new()
+                    });
+                (mock_fold_scalars_challenge, builder)
+            });
+
+        let mut seq = Sequence::new();
+        let mut state = MockProverState::new();
+
+        // Final scalar product (no reduce steps)
+        state
+            .expect_compute_scalar_product_message()
+            .times(1)
+            .returning(move |setup, challenge| {
+                assert_eq!(setup, &mock_setup);
+                assert_eq!(challenge, mock_fold_scalars_challenge);
+                mock_scalar_product_message
+            })
+            .in_sequence(&mut seq);
+
+        inner_product_prove(builder, state, &mock_setup, 0);
+    }
+
+    #[test]
     fn we_can_prove_inner_product_with_1_round() {
         let rng = &mut rand::rng();
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// The first prover message in the Dory-Reduce portion (Section 3.2) of the Dory protocol.
 ///
 /// This consists of $D_{1L}$, $D_{1R}$, $D_{2L}$, $D_{2R}$, $E_{1\beta}$, and $E_{2\beta}$.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FirstReduceMessage<G1, G2, GT> {
     /// $D_{1L}$
     pub d1_left: GT,
@@ -23,7 +23,7 @@ pub struct FirstReduceMessage<G1, G2, GT> {
 ///
 /// The challenge, $\beta$, is a random scalar. Additionally, $\beta$ must be non-zero because
 /// the protocol uses $\beta^{-1}$, which we also include here.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FirstReduceChallenge<Scalar> {
     /// $\beta$
     pub beta: Scalar,
@@ -34,7 +34,7 @@ pub struct FirstReduceChallenge<Scalar> {
 /// The second prover message in the Dory-Reduce portion (Section 3.2) of the Dory protocol.
 ///
 /// This consists of $C_+$, $C_-$, $E_{1+}$, $E_{1-}$, $E_{2+}$, and $E_{2-}$.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SecondReduceMessage<G1, G2, GT> {
     /// $C_+$
     pub c_plus: GT,
@@ -54,7 +54,7 @@ pub struct SecondReduceMessage<G1, G2, GT> {
 ///
 /// The challenge, $\alpha$, is a random scalar. Additionally, $\alpha$ must be non-zero because
 /// the protocol uses $\alpha^{-1}$, which we also include here.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SecondReduceChallenge<Scalar> {
     /// $\alpha$
     pub alpha: Scalar,
@@ -66,7 +66,7 @@ pub struct SecondReduceChallenge<Scalar> {
 ///
 /// The challenge, $\gamma$, is a random scalar. Additionally, $\gamma$ must be non-zero because
 /// the protocol uses $\gamma^{-1}$, which we also include here.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FoldScalarsChallenge<Scalar> {
     /// $\gamma$
     pub gamma: Scalar,
@@ -77,7 +77,7 @@ pub struct FoldScalarsChallenge<Scalar> {
 /// The prover message in the Scalar-Product portion (Section 3.1) of the Dory protocol.
 ///
 /// This consists of $E_1$ and $E_2$.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ScalarProductMessage<G1, G2> {
     /// $E_1$
     pub e1: G1,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -84,3 +84,198 @@ pub struct ScalarProductMessage<G1, G2> {
     /// $E_2$
     pub e2: G2,
 }
+
+/// This module provides random message generation for testing purposes.
+/// This could, in theory, easily be hidden behind a `random` feature flag,
+/// but there is no obvious use case for this.
+#[cfg(test)]
+mod random_messages {
+
+    use rand::distr::{Distribution, StandardUniform};
+
+    use super::{
+        FirstReduceChallenge, FirstReduceMessage, FoldScalarsChallenge, ScalarProductMessage,
+        SecondReduceChallenge, SecondReduceMessage,
+    };
+
+    impl<G1, G2, GT> Distribution<FirstReduceMessage<G1, G2, GT>> for StandardUniform
+    where
+        StandardUniform: Distribution<G1>,
+        StandardUniform: Distribution<G2>,
+        StandardUniform: Distribution<GT>,
+    {
+        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> FirstReduceMessage<G1, G2, GT> {
+            FirstReduceMessage {
+                d1_left: self.sample(rng),
+                d1_right: self.sample(rng),
+                d2_left: self.sample(rng),
+                d2_right: self.sample(rng),
+                e1_beta: self.sample(rng),
+                e2_beta: self.sample(rng),
+            }
+        }
+    }
+
+    impl<Scalar> Distribution<FirstReduceChallenge<Scalar>> for StandardUniform
+    where
+        StandardUniform: Distribution<Scalar>,
+    {
+        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> FirstReduceChallenge<Scalar> {
+            FirstReduceChallenge {
+                beta: self.sample(rng),
+                beta_inverse: self.sample(rng),
+            }
+        }
+    }
+
+    impl<G1, G2, GT> Distribution<SecondReduceMessage<G1, G2, GT>> for StandardUniform
+    where
+        StandardUniform: Distribution<G1>,
+        StandardUniform: Distribution<G2>,
+        StandardUniform: Distribution<GT>,
+    {
+        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> SecondReduceMessage<G1, G2, GT> {
+            SecondReduceMessage {
+                c_plus: self.sample(rng),
+                c_minus: self.sample(rng),
+                e1_plus: self.sample(rng),
+                e1_minus: self.sample(rng),
+                e2_plus: self.sample(rng),
+                e2_minus: self.sample(rng),
+            }
+        }
+    }
+
+    impl<Scalar> Distribution<SecondReduceChallenge<Scalar>> for StandardUniform
+    where
+        StandardUniform: Distribution<Scalar>,
+    {
+        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> SecondReduceChallenge<Scalar> {
+            SecondReduceChallenge {
+                alpha: self.sample(rng),
+                alpha_inverse: self.sample(rng),
+            }
+        }
+    }
+
+    impl<Scalar> Distribution<FoldScalarsChallenge<Scalar>> for StandardUniform
+    where
+        StandardUniform: Distribution<Scalar>,
+    {
+        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> FoldScalarsChallenge<Scalar> {
+            FoldScalarsChallenge {
+                gamma: self.sample(rng),
+                gamma_inverse: self.sample(rng),
+            }
+        }
+    }
+
+    impl<G1, G2> Distribution<ScalarProductMessage<G1, G2>> for StandardUniform
+    where
+        StandardUniform: Distribution<G1>,
+        StandardUniform: Distribution<G2>,
+    {
+        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> ScalarProductMessage<G1, G2> {
+            ScalarProductMessage {
+                e1: self.sample(rng),
+                e2: self.sample(rng),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rand_core::impls::fill_bytes_via_next;
+    use rand::{Rng, RngCore};
+
+    use super::{
+        FirstReduceChallenge, FirstReduceMessage, FoldScalarsChallenge, ScalarProductMessage,
+        SecondReduceChallenge, SecondReduceMessage,
+    };
+
+    struct MockRng {
+        next: u64,
+    }
+    impl RngCore for MockRng {
+        #[expect(clippy::cast_possible_truncation)]
+        fn next_u32(&mut self) -> u32 {
+            self.next_u64() as u32
+        }
+        fn next_u64(&mut self) -> u64 {
+            self.next += 1;
+            self.next - 1
+        }
+        fn fill_bytes(&mut self, dst: &mut [u8]) {
+            fill_bytes_via_next(self, dst);
+        }
+    }
+
+    #[test]
+    fn we_can_generate_sequential_values_from_mock_rng() {
+        let mut rng = MockRng { next: 0 };
+        assert_eq!(rng.next_u32(), 0);
+        assert_eq!(rng.next_u32(), 1);
+        assert_eq!(rng.next_u64(), 2);
+        assert_eq!(rng.next_u64(), 3);
+        let mut buf = [0u8; 10];
+        rng.fill_bytes(&mut buf);
+        assert_eq!(buf, [4, 0, 0, 0, 0, 0, 0, 0, 5, 0]);
+        assert_eq!(rng.random::<u64>(), 6);
+        assert_eq!(rng.random::<u32>(), 7);
+        assert_eq!(rng.random::<i64>(), 8);
+        assert_eq!(rng.random::<i32>(), 9);
+    }
+
+    #[test]
+    fn we_can_generate_random_messages() {
+        let mut rng = MockRng { next: 0 };
+        assert_eq!(
+            rng.random::<FirstReduceMessage<u32, u64, u32>>(),
+            FirstReduceMessage {
+                d1_left: 0,
+                d1_right: 1,
+                d2_left: 2,
+                d2_right: 3,
+                e1_beta: 4,
+                e2_beta: 5,
+            }
+        );
+        assert_eq!(
+            rng.random::<FirstReduceChallenge<u32>>(),
+            FirstReduceChallenge {
+                beta: 6,
+                beta_inverse: 7,
+            }
+        );
+        assert_eq!(
+            rng.random::<SecondReduceMessage<u32, u64, u32>>(),
+            SecondReduceMessage {
+                c_plus: 8,
+                c_minus: 9,
+                e1_plus: 10,
+                e1_minus: 11,
+                e2_plus: 12,
+                e2_minus: 13,
+            }
+        );
+        assert_eq!(
+            rng.random::<SecondReduceChallenge<u32>>(),
+            SecondReduceChallenge {
+                alpha: 14,
+                alpha_inverse: 15,
+            }
+        );
+        assert_eq!(
+            rng.random::<FoldScalarsChallenge<u32>>(),
+            FoldScalarsChallenge {
+                gamma: 16,
+                gamma_inverse: 17,
+            }
+        );
+        assert_eq!(
+            rng.random::<ScalarProductMessage<u32, u64>>(),
+            ScalarProductMessage { e1: 18, e2: 19 }
+        );
+    }
+}


### PR DESCRIPTION
# Rationale for this change

The `inner_product_prove` is currently uncovered by tests.

# What changes are included in this PR?

See individual commits:
* Added implementations for random generation of messages for testing purposes
* Added tests of `inner_product_prove` using mock builder and state. NOTE: this is fairly convoluted.
# Are these changes tested?

Yes